### PR TITLE
chore: README cleanup (remove stats/stargazers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,8 +937,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ### 🌟 Stargazers Community
 
-[![Stargazers repo roster for @muhittincamdali/iOS-Notification-Framework](https://starchart.cc/muhittincamdali/iOS-Notification-Framework.svg)](https://github.com/muhittincamdali/iOS-Notification-Framework/stargazers)
-
 **⭐ Star this repository if it helped you!**
 
 **💫 Join our amazing community of developers!**


### PR DESCRIPTION
Removes analytics/stargazers sections to keep README focused.