### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,29 @@
+# Documentation Index
+
+- [](&)Documentation/AccessibilityAPI.md
+- [](&)Documentation/AccessibilityGuide.md
+- [](&)Documentation/AnalyticsAPI.md
+- [](&)Documentation/AnalyticsGuide.md
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/API/APIReference.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/CustomActionsAPI.md
+- [](&)Documentation/CustomActionsGuide.md
+- [](&)Documentation/CustomizationAPI.md
+- [](&)Documentation/CustomizationGuide.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/Guides/AdvancedFeatures.md
+- [](&)Documentation/Guides/BestPractices.md
+- [](&)Documentation/Guides/GettingStarted.md
+- [](&)Documentation/Guides/MigrationGuide.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/LocalizationAPI.md
+- [](&)Documentation/LocalizationGuide.md
+- [](&)Documentation/NotificationManagerAPI.md
+- [](&)Documentation/RichMediaAPI.md
+- [](&)Documentation/RichMediaGuide.md
+- [](&)Documentation/SchedulingAPI.md
+- [](&)Documentation/SchedulingGuide.md
+- [](&)Documentation/Troubleshooting.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,18 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/Advanced/AdvancedNotificationExample.swift
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExamples/AdvancedConflictResolutionExample.swift
+- ``Examples/AnalyticsExamples/AnalyticsExample.swift
+- ``Examples/Basic/BasicNotificationExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExamples/BasicNotificationExample.swift
+- ``Examples/BasicNotifications/BasicNotificationExample.swift
+- ``Examples/Custom/CustomNotificationExample.swift
+- ``Examples/CustomActions/CustomActionExample.swift
+- ``Examples/CustomActionsExamples/CustomActionsExample.swift
+- ``Examples/CustomizationExamples/CustomizationExample.swift
+- ``Examples/RichMediaExamples/RichMediaNotificationExample.swift
+- ``Examples/RichMediaNotifications/RichMediaNotificationExample.swift
+- ``Examples/SchedulingExamples/SchedulingExample.swift
+- ``Examples/SynchronizationExamples/BackgroundSyncExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.