### PR TITLE
chore(ci): README Guard + CODEOWNERS docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # Default ownership
 * @maintainers
 README.md @maintainers
+Documentation/** @maintainers


### PR DESCRIPTION
Adds README Guard workflow and ensures Documentation/** is owned.